### PR TITLE
Here i added a comma to improve the syntax (for admin person create),…

### DIFF
--- a/docs/rest-api/people.md
+++ b/docs/rest-api/people.md
@@ -87,7 +87,7 @@ The API enables an admin to create a person. The following parameters listed bel
   -H "Cache-Control: no-cache"
   -d '{
     "name": "Test Staff",
-    "description": "Test description"
+    "description": "Test description",
     "email": "test@test.com",
     "phone_prefix": "44",
     "phone": "07912345678",
@@ -105,7 +105,7 @@ Above is an example cURL call for creating a new person.
 
 ## Update Person
 
-You can update information of a person. The parameters stated below are supported. You must be authenticated as an administrator to make this call. 
+You can update information of a person. The parameters stated below are supported. You must be authenticated as an administrator to make this call.
 
 ### Parameters
 <table class="pure-table">


### PR DESCRIPTION
… otherwise the API call for the staff creation just fails with 500 internal server error.